### PR TITLE
Proof of concept: adding Python bindings

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,8 @@
+*.o
+*.so
+.cache
+__pycache__
+*.egg-info
+dist
+build
+legendre_rule_fast.cpp

--- a/python/demo.py
+++ b/python/demo.py
@@ -1,0 +1,23 @@
+import time
+import finufft
+import numpy as np
+
+np.random.seed(42)
+
+acc = 1.e-9
+N = int(1e6)
+M = int(1e6)
+x = np.random.uniform(-np.pi, np.pi, N)
+c = np.random.randn(N) + 1.j * np.random.randn(N)
+
+strt = time.time()
+F = finufft.nufft1d1(x, c, M, acc)
+print("Finished nufft in {0:.2e} seconds. Checking..."
+      .format(time.time()-strt))
+
+n = 142519
+Ftest = 0.0
+for j in range(M):
+    Ftest += c[j] * np.exp(n * x[j] * 1.j) / M
+err = np.abs((F[n + N // 2] - Ftest) / Ftest)
+print("Error: {0}".format(err))

--- a/python/finufft/__init__.py
+++ b/python/finufft/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+__version__ = "0.0.1.dev0"
+
+try:
+    __FINUFFT_SETUP__
+except NameError:
+    __FINUFFT_SETUP__ = False
+
+if not __FINUFFT_SETUP__:
+    __all__ = ["nufft1d1"]
+
+    from .interface import nufft1d1

--- a/python/finufft/build.py
+++ b/python/finufft/build.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import os
+import sys
+import tempfile
+
+import setuptools
+from setuptools.command.build_ext import build_ext as _build_ext
+
+__all__ = ["build_ext"]
+
+def has_flag(compiler, flagname):
+    """Return a boolean indicating whether a flag name is supported on
+    the specified compiler.
+    """
+    with tempfile.NamedTemporaryFile("w", suffix=".cpp") as f:
+        f.write("int main (int argc, char **argv) { return 0; }")
+        try:
+            compiler.compile([f.name], extra_postargs=[flagname])
+        except setuptools.distutils.errors.CompileError:
+            return False
+    return True
+
+def cpp_flag(compiler):
+    """Return the -std=c++[11/14] compiler flag.
+
+    The c++14 is prefered over c++11 (when it is available).
+    """
+    if has_flag(compiler, "-std=c++14"):
+        return "-std=c++14"
+    elif has_flag(compiler, "-std=c++11"):
+        return "-std=c++11"
+    else:
+        raise RuntimeError("Unsupported compiler -- at least C++11 support "
+                           "is needed!")
+
+class build_ext(_build_ext):
+    """
+    A custom extension builder that finds the include directories for Eigen
+    before compiling.
+
+    """
+
+    c_opts = {
+        "msvc": ["/EHsc"],
+        "unix": [],
+    }
+
+    if sys.platform == "darwin":
+        c_opts["unix"] += ["-stdlib=libc++", "-mmacosx-version-min=10.7"]
+
+    def build_extensions(self):
+        # Add the libraries
+        libraries = ["fftw3", "fftw3_threads"]
+        if os.name == "posix":
+            libraries += ["m", "stdc++"]
+        for ext in self.extensions:
+            ext.libraries += libraries
+
+        # Add the numpy and pybind11 include directories
+        import numpy
+        import pybind11
+        include_dirs = [
+            numpy.get_include(),
+            pybind11.get_include(False),
+            pybind11.get_include(True),
+        ]
+        for ext in self.extensions:
+            ext.include_dirs += include_dirs
+
+        # Set up pybind11
+        ct = self.compiler.compiler_type
+        opts = self.c_opts.get(ct, [])
+        if ct == "unix":
+            opts.append("-DVERSION_INFO=\"{0:s}\""
+                        .format(self.distribution.get_version()))
+            opts.append(cpp_flag(self.compiler))
+            for flag in ["-funroll-loops", "-fvisibility=hidden",
+                         "-Wno-unused-function", "-Wno-uninitialized", "-O4"]:
+                if has_flag(self.compiler, flag):
+                    opts.append(flag)
+        elif ct == "msvc":
+            opts.append('/DVERSION_INFO=\\"{0:s}\\"'
+                        .format(self.distribution.get_version()))
+        for ext in self.extensions:
+            ext.extra_compile_args = opts
+
+        # Run the standard build procedure.
+        _build_ext.build_extensions(self)

--- a/python/finufft/interface.cpp
+++ b/python/finufft/interface.cpp
@@ -1,0 +1,44 @@
+#include <vector>
+#include <complex>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+#include "finufft.h"
+
+namespace py = pybind11;
+typedef std::complex<double> complex_t;
+
+py::array_t<complex_t> nufft1d1(py::array_t<double> x, py::array_t<complex_t> c, int n_modes, double accuracy) {
+  auto buf_x = x.request(), buf_c = c.request();
+
+  if (buf_x.ndim != 1 || buf_c.ndim != 1)
+    throw std::runtime_error("Number of dimensions must be one");
+  if (buf_x.size != buf_c.size)
+    throw std::runtime_error("Input shapes must match");
+  long M = buf_x.size;
+
+  nufft_opts opts;
+  auto result = py::array_t<complex_t>(n_modes);
+  auto buf_F = result.request();
+  int ier = finufft1d1(M, (double*)buf_x.ptr, (complex_t*)buf_c.ptr, +1, accuracy, n_modes, (complex_t*)buf_F.ptr, opts);
+  if (ier != 0) {
+    std::ostringstream msg;
+    msg << "finufft1d1 failed with code " << ier;
+    throw std::runtime_error(msg.str());
+  }
+
+  return result;
+}
+
+PYBIND11_PLUGIN(interface) {
+  py::module m("interface", R"delim(
+Docs
+)delim");
+
+  m.def("nufft1d1", &nufft1d1, R"delim(
+Docs
+)delim");
+
+  return m.ptr();
+}

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import shutil
+
+from setuptools import setup, Extension
+
+# Publish the library to PyPI.
+if "publish" in sys.argv[-1]:
+    os.system("python setup.py sdist upload")
+    sys.exit()
+
+# The directory for the finufft source
+srcdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+contribdir = os.path.join(srcdir, "contrib")
+
+# Hack the legendre_rule_fast code to think that it's C++
+lrsrc = "legendre_rule_fast.cpp"
+shutil.copyfile(os.path.join(contribdir, "legendre_rule_fast.c"), lrsrc)
+
+srcdir = os.path.join(srcdir, "src")
+srcfiles = [
+    "cnufftspread.cpp", "utils.cpp", "common.cpp", "twopispread.cpp",
+    "finufft1d.cpp", "finufft2d.cpp", "finufft3d.cpp",
+]
+srcfiles = [os.path.join(srcdir, fn) for fn in srcfiles]
+srcfiles += [lrsrc]
+if not os.path.exists(os.path.join(srcdir, "finufft.h")):
+    raise RuntimeError("Couldn't find the finufft source")
+
+srcfiles += [os.path.join("finufft", "interface.cpp")]
+ext = Extension("finufft.interface",
+                sources=srcfiles,
+                # language="c++",
+                include_dirs=[srcdir, contribdir])
+
+# Hackishly inject a constant into builtins to enable importing of the
+# package before the library is built.
+if sys.version_info[0] < 3:
+    import __builtin__ as builtins
+else:
+    import builtins
+builtins.__FINUFFT_SETUP__ = True
+import finufft  # NOQA
+from finufft.build import build_ext  # NOQA
+
+setup(
+    name="finufft",
+    version=finufft.__version__,
+    author="Daniel Foreman-Mackey",
+    author_email="foreman.mackey@gmail.com",
+    url="https://github.com/ahbarnett/finufft",
+    license="TBD",
+    packages=["finufft"],
+    install_requires=["numpy", "pybind11"],
+    ext_modules=[ext],
+    description="Flatiron Institute Nonuniform Fast Fourier Transform",
+    long_description=open("README.rst").read(),
+    package_data={"": ["README.rst", "LICENSE",
+                       os.path.join(srcdir, "*.h"),
+                       os.path.join(contribdir, "*", "*.h")]},
+    include_package_data=True,
+    cmdclass=dict(build_ext=build_ext),
+    classifiers=[
+        # "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        # "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+    ],
+    zip_safe=True,
+)


### PR DESCRIPTION
Here's a proof of concept demo of how we might add Python bindings using [pybind11](https://github.com/pybind/pybind11). Most of the code is still boilerplate and the good stuff is all in `python/finufft/interface.cpp`. To test this, navigate to the `python` directory and run:

```bash
python setup.py build_ext --inplace
```

And if that succeeds, try:

```bash
python demo.py
```

To run an example that is equivalent to the one in `examples/example1d1.cpp`.

I've only implemented the `nufft1d1` function but I'd be happy to add the others if this looks good to you!