### PR TITLE
Adding OpenMP support to Python bindings

### DIFF
--- a/python/demo.py
+++ b/python/demo.py
@@ -11,7 +11,7 @@ x = np.random.uniform(-np.pi, np.pi, N)
 c = np.random.randn(N) + 1.j * np.random.randn(N)
 
 strt = time.time()
-F = finufft.nufft1d1(x, c, M, acc)
+F = finufft.nufft1d1(x, c, M, acc, 1)
 print("Finished nufft in {0:.2e} seconds. Checking..."
       .format(time.time()-strt))
 

--- a/python/finufft/interface.cpp
+++ b/python/finufft/interface.cpp
@@ -9,7 +9,7 @@
 namespace py = pybind11;
 typedef std::complex<double> complex_t;
 
-py::array_t<complex_t> nufft1d1(py::array_t<double> x, py::array_t<complex_t> c, int n_modes, double accuracy) {
+py::array_t<complex_t> nufft1d1(py::array_t<double> x, py::array_t<complex_t> c, int n_modes, double accuracy, int debug) {
   auto buf_x = x.request(), buf_c = c.request();
 
   if (buf_x.ndim != 1 || buf_c.ndim != 1)
@@ -19,6 +19,7 @@ py::array_t<complex_t> nufft1d1(py::array_t<double> x, py::array_t<complex_t> c,
   long M = buf_x.size;
 
   nufft_opts opts;
+  opts.debug = debug;
   auto result = py::array_t<complex_t>(n_modes);
   auto buf_F = result.request();
   int ier = finufft1d1(M, (double*)buf_x.ptr, (complex_t*)buf_c.ptr, +1, accuracy, n_modes, (complex_t*)buf_F.ptr, opts);


### PR DESCRIPTION
I've added OpenMP support to the Python bindings. They seem to work on my Mac - the demo prints the following with `debug=1`:

```
1d1: ms=1000000 nf1=2000000 nj=1000000 ...
fftw plan                0.009 s
spread (ier=0):          0.329 s
fft (4 threads):         0.106 s
kernel fser (ns=10):     0.101 s
deconvolve & copy out:   0.012 s
freed
Finished nufft in 5.71e-01 seconds. Checking...
Error: 2.9159166847782386e-10
```

If you run something like:

```bash
cd python
rm -rf build
python setup.py build_ext --inplace
```

it should link to OpenMP if it's available. I haven't been able to test on Linux yet but on my Mac I had to do the following to get OpenMP set up:

```bash
brew reinstall gcc --without-multilib
brew reinstall fftw --with-openmp
CC=/usr/local/bin/gcc-6 CXX=/usr/local/bin/g++-6 python setup.py build_ext --inplace
```