### PR TITLE
Modernizing timer code

### DIFF
--- a/src/cnufftspread.cpp
+++ b/src/cnufftspread.cpp
@@ -125,14 +125,14 @@ int cnufftspread(
   FLT ns2 = (FLT)ns/2;          // half spread width, used as stencil shift
   int numkervals = (int)pow(ns,ndims);
   if (opts.debug)
-    printf("starting spread %dD (dir=%d, N1=%ld,N2=%ld,N3=%ld), %d threads\n",ndims,opts.spread_direction,N1,N2,N3,MY_OMP_GET_MAX_THREADS());
-  
+    printf("starting spread %dD (dir=%d, N1=%lld,N2=%lld,N3=%lld), %d threads\n",ndims,opts.spread_direction,N1,N2,N3,MY_OMP_GET_MAX_THREADS());
+
   if (opts.chkbnds) {            // check NU pts are in bounds, exit gracefully
     timer.start();
     for (BIGINT i=0; i<M; ++i) {
       FLT x=RESCALE(kx[i],N1,opts.pirange);
       if (x<0 || x>N1) {
-	fprintf(stderr,"nonuniform pt out of range: kx=%g, N1=%ld (pirange=%d)\n",x,N1,opts.pirange);
+	fprintf(stderr,"nonuniform pt out of range: kx=%g, N1=%lld (pirange=%d)\n",x,N1,opts.pirange);
 	return ERR_SPREAD_PTS_OUT_RANGE;
       }
     }
@@ -140,7 +140,7 @@ int cnufftspread(
       for (BIGINT i=0; i<M; ++i) {
 	FLT y=RESCALE(ky[i],N2,opts.pirange);
 	if (y<0 || y>N2) {
-	  fprintf(stderr,"nonuniform pt out of range: ky=%g, N2=%ld (pirange=%d)\n",y,N2,opts.pirange);
+	  fprintf(stderr,"nonuniform pt out of range: ky=%g, N2=%lld (pirange=%d)\n",y,N2,opts.pirange);
 	  return ERR_SPREAD_PTS_OUT_RANGE;
 	}
       }
@@ -148,7 +148,7 @@ int cnufftspread(
       for (BIGINT i=0; i<M; ++i) {
 	FLT z=RESCALE(kz[i],N3,opts.pirange);
 	if (z<0 || z>N3) {
-	  fprintf(stderr,"nonuniform pt out of range: kz=%g, N3=%ld (pirange=%d)\n",z,N3,opts.pirange);
+	  fprintf(stderr,"nonuniform pt out of range: kz=%g, N3=%lld (pirange=%d)\n",z,N3,opts.pirange);
 	  return ERR_SPREAD_PTS_OUT_RANGE;
 	}
       }
@@ -165,7 +165,7 @@ int cnufftspread(
       sort_indices[i]=i;                      // the identity permutation
   if (opts.debug)
     printf("sort time (sort=%d): %.3g s\n",(int)opts.sort,timer.elapsedsec());
-  
+
 
   if (opts.spread_direction==1) { // ========= direction 1 (spreading) =======
 
@@ -178,7 +178,7 @@ int cnufftspread(
     int nthr = MY_OMP_GET_MAX_THREADS();
     std::vector<Subproblem> s;  // create set of subproblems
     int nb;
-    
+
     int nospatialsplit = 1;  // hardcoded for now
     if (nospatialsplit) {   // split sorted inds (advanced2), could double RAM
       nb = MIN(4*nthr,M);
@@ -211,7 +211,7 @@ int cnufftspread(
       int nb1=ceil((FLT)N1/w1), nb2=ceil((FLT)N2/w2), nb3=ceil((FLT)N3/w3);
       nb = nb1*nb2*nb3;               // update to actual # boxes
       if (opts.debug) printf("%dx%dx%d subproblem boxes size %dx%dx%d\n",nb1,nb2,nb3,w1,w2,w3);
-      
+
       s.resize(nb);  // create nb subproblems
       for (BIGINT i=0; i<M; i++) {    // build subproblem indices in sorted order
 	BIGINT j = sort_indices[i];
@@ -223,7 +223,7 @@ int cnufftspread(
 	// append this source pt's index to the appropriate subproblem's index list
 	s.at(si).nonuniform_indices.push_back(j);  // hard to parallelize
       }
-      
+
       // split subproblems by index chunks so none exceed opts.max_subproblem_size
       BIGINT num_nonempty_subproblems=0; // for information only (verbose output)
       for (BIGINT i=0; i<nb; i++) {
@@ -249,7 +249,7 @@ int cnufftspread(
     }
     nb = s.size();
     if (opts.debug) printf("subprobs setup %.3g s (%d subprobs)\n",timer.elapsedsec(),nb);
-    
+
 #pragma omp parallel for //schedule(dynamic,1)
     for (int isub=0; isub<nb; isub++) { // Main loop through the subproblems
       std::vector<BIGINT> inds = s.at(isub).nonuniform_indices;
@@ -273,13 +273,14 @@ int cnufftspread(
 	// get the subgrid which will include padding by roughly nspread/2
 	BIGINT offset1,offset2,offset3,size1,size2,size3; // get_subgrid sets
 	get_subgrid(offset1,offset2,offset3,size1,size2,size3,M0,kx0,ky0,kz0,ns,ndims);
-	if (opts.debug>1)  // verbose
+	if (opts.debug>1) {  // verbose
 	  if (ndims==1)
-	    printf("subgrid: off %ld\t siz %ld\t #NU %ld\n",offset1,size1,M0);
-	  else if (ndims==2)
-	    printf("subgrid: off %ld,%ld\t siz %ld,%ld\t #NU %ld\n",offset1,offset2,size1,size2,M0);
-	  else
-	    printf("subgrid: off %ld,%ld,%ld\t siz %ld,%ld,%ld\t #NU %ld\n",offset1,offset2,offset3,size1,size2,size3,M0);
+	    printf("subgrid: off %lld\t siz %lld\t #NU %lld\n",offset1,size1,M0);
+    else if (ndims==2)
+	    printf("subgrid: off %lld,%lld\t siz %lld,%lld\t #NU %lld\n",offset1,offset2,size1,size2,M0);
+    else
+	    printf("subgrid: off %lld,%lld,%lld\t siz %lld,%lld,%lld\t #NU %lld\n",offset1,offset2,offset3,size1,size2,size3,M0);
+  }
 	for (BIGINT j=0; j<M0; j++) {
 	  kx0[j]-=offset1;  // now kx0 coords are relative to corner of subgrid
 	  if (N2>1) ky0[j]-=offset2;  // only accessed if 2D or 3D
@@ -289,14 +290,15 @@ int cnufftspread(
 	FLT* du0=(FLT*)malloc(sizeof(FLT)*2*size1*size2*size3); // complex
 
 	// Spread to subgrid without need for bounds checking or wrapping
-	if (!(opts.flags & TF_OMIT_SPREADING))
+	if (!(opts.flags & TF_OMIT_SPREADING)) {
 	  if (ndims==1)
 	    spread_subproblem_1d(size1,du0,M0,kx0,dd0,opts);
 	  else if (ndims==2)
 	    spread_subproblem_2d(size1,size2,du0,M0,kx0,ky0,dd0,opts);
 	  else
 	    spread_subproblem_3d(size1,size2,size3,du0,M0,kx0,ky0,kz0,dd0,opts);
-	
+  }
+
 	// Add the subgrid to output grid, wrapping (slower). Works in all dims.
 	BIGINT o1[size1], o2[size2], o3[size3];  // alloc 1d output ptr lists
 	BIGINT x=offset1, y=offset2, z=offset3;  // fill lists with wrapping...
@@ -334,21 +336,21 @@ int cnufftspread(
 	} // end critical block
       }
     }     // end main loop over subprobs
-    
+
   } else {          // ================= direction 2 (interpolation) ===========
 
 #pragma omp parallel for schedule(dynamic,10000) // (dynamic not needed) assign threads to NU targ pts:
     for (BIGINT i=0; i<M; i++) {   // main loop over NU targs, interp each from U
       BIGINT j=sort_indices[i];    // j current index in input NU targ list
-    
+
       // coords (x,y,z), spread block corner index (i1,i2,i3) of current NU targ
       FLT xj=RESCALE(kx[j],N1,opts.pirange);
       BIGINT i1=(BIGINT)std::ceil(xj-ns2); // leftmost grid index
       FLT x1=(FLT)i1-xj;          // real-valued shifts of ker center
       FLT kernel_values[numkervals];
-      
+
       // eval kernel values patch and use to interpolate from uniform data...
-      if (!(opts.flags & TF_OMIT_SPREADING))
+      if (!(opts.flags & TF_OMIT_SPREADING)) {
 	if (ndims==1) {                                          // 1D
 	  fill_kernel_line(x1,opts,kernel_values);
 	  interp_line(&data_nonuniform[2*j],data_uniform,kernel_values,i1,N1,ns);
@@ -368,6 +370,7 @@ int cnufftspread(
 	  fill_kernel_cube(x1,x2,x3,opts,kernel_values);
 	  interp_cube(&data_nonuniform[2*j],data_uniform,kernel_values,i1,i2,i3,N1,N2,N3,ns);
 	}
+      }
     }    // end NU targ loop
   }                           // ================= end direction choice ========
 
@@ -771,7 +774,7 @@ void bin_sort(BIGINT *ret, BIGINT M, FLT *kx, FLT *ky, FLT *kz,
  * then reading out the indices within
  * these boxes in the natural box order (x fastest, y med, z slowest).
  * Finally the permutation is inverted.
- * 
+ *
  * Inputs: M - length of inputs
  *         kx,ky,kz - length-M real numbers in [0,N1], [0,N2], [0,N3]
  *                    respectively, if pirange=0; or in [-pi,pi] if pirange=1
@@ -792,7 +795,7 @@ void bin_sort(BIGINT *ret, BIGINT M, FLT *kx, FLT *ky, FLT *kz,
   BIGINT nbins3=N3/bin_size_z+1;
   BIGINT nbins = nbins1*nbins2*nbins3;
   bool isky=(N2>1), iskz=(N3>1);  // ky,kz available? must not access if not!
-  
+
   std::vector<BIGINT> counts(nbins,0);  // count how many pts in each bin
   for (BIGINT i=0; i<M; i++) {
     // find the bin index

--- a/src/finufft1d.cpp
+++ b/src/finufft1d.cpp
@@ -12,7 +12,7 @@ int finufft1d1(INT nj,FLT* xj,CPX* cj,int iflag,FLT eps,INT ms,
 
               nj-1
      fk(k1) = SUM cj[j] exp(+/-i k1 xj(j))  for -ms/2 <= k1 <= (ms-1)/2
-              j=0                            
+              j=0
    Inputs:
      nj     number of sources (type INT; see utils.h)
      xj     location of sources on interval [-pi,pi].
@@ -54,7 +54,7 @@ int finufft1d1(INT nj,FLT* xj,CPX* cj,int iflag,FLT eps,INT ms,
   }
   cout << scientific << setprecision(15);  // for debug
 
-  if (opts.debug) printf("1d1: ms=%ld nf1=%ld nj=%ld ...\n",(INT64)ms,nf1,(INT64)nj);
+  if (opts.debug) printf("1d1: ms=%lld nf1=%lld nj=%lld ...\n",(INT64)ms,nf1,(INT64)nj);
 
   CNTime timer; timer.start();
   int nth = MY_OMP_GET_MAX_THREADS();
@@ -108,7 +108,7 @@ int finufft1d2(INT nj,FLT* xj,CPX* cj,int iflag,FLT eps,INT ms,
  /*  Type-2 1D complex nonuniform FFT.
 
      cj[j] = SUM   fk[k1] exp(+/-i k1 xj[j])      for j = 0,...,nj-1
-             k1 
+             k1
      where sum is over -ms/2 <= k1 <= (ms-1)/2.
 
    Inputs:
@@ -150,7 +150,7 @@ int finufft1d2(INT nj,FLT* xj,CPX* cj,int iflag,FLT eps,INT ms,
   }
   cout << scientific << setprecision(15);  // for debug
 
-  if (opts.debug) printf("1d2: ms=%ld nf1=%ld nj=%ld ...\n",(INT64)ms,nf1,(INT64)nj); 
+  if (opts.debug) printf("1d2: ms=%lld nf1=%lld nj=%lld ...\n",(INT64)ms,nf1,(INT64)nj);
 
   // STEP 0: get FT of real symmetric spreading kernel
   CNTime timer; timer.start();
@@ -236,7 +236,7 @@ int finufft1d3(INT nj,FLT* xj,CPX* cj,int iflag, FLT eps, INT nk, FLT* s, CPX* f
 
    No references to FFTW are needed here. CPX arithmetic is used,
    thus compile with -Ofast in GNU.
-   Barnett 2/7/17-6/9/17. 
+   Barnett 2/7/17-6/9/17.
  */
 {
   spread_opts spopts;
@@ -251,7 +251,7 @@ int finufft1d3(INT nj,FLT* xj,CPX* cj,int iflag, FLT eps, INT nk, FLT* s, CPX* f
   arraywidcen((BIGINT)nj,xj,&X1,&C1);  // get half-width, center, containing {x_j}
   arraywidcen((BIGINT)nk,s,&S1,&D1);   // get half-width, center, containing {s_k}
   set_nhg_type3(S1,X1,opts,spopts,&nf1,&h1,&gam1);          // applies twist i)
-  if (opts.debug) printf("1d3: X1=%.3g C1=%.3g S1=%.3g D1=%.3g gam1=%g nf1=%ld nj=%ld nk=%ld...\n",X1,C1,S1,D1,gam1,nf1,(INT64)nj,(INT64)nk);
+  if (opts.debug) printf("1d3: X1=%.3g C1=%.3g S1=%.3g D1=%.3g gam1=%g nf1=%lld nj=%lld nk=%lld...\n",X1,C1,S1,D1,gam1,nf1,(INT64)nj,(INT64)nk);
   if (nf1>MAX_NF) {
     fprintf(stderr,"nf1=%.3g exceeds MAX_NF of %.3g\n",(double)nf1,(double)MAX_NF);
     return ERR_MAXNALLOC;
@@ -269,7 +269,7 @@ int finufft1d3(INT nj,FLT* xj,CPX* cj,int iflag, FLT eps, INT nk, FLT* s, CPX* f
   } else
     for (BIGINT j=0;j<nj;++j)
       cpj[j] = cj[j];                                    // just copy over
-  
+
   // Step 1: spread from irregular sources to regular grid as in type 1
   CPX* fw = (CPX*)malloc(sizeof(CPX)*nf1);
   timer.restart();

--- a/src/finufft2d.cpp
+++ b/src/finufft2d.cpp
@@ -13,17 +13,17 @@ int finufft2d1(INT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,
                   nj-1
      f[k1,k2] =   SUM  c[j] exp(+-i (k1 x[j] + k2 y[j]))
                   j=0
- 
+
      for -ms/2 <= k1 <= (ms-1)/2,  -mt/2 <= k2 <= (mt-1)/2.
 
      The output array is in increasing k1 ordering (fast), then increasing
      k2 ordering (slow). If iflag>0 the + sign is
      used, otherwise the - sign is used, in the exponential.
-                           
+
    Inputs:
      nj     number of sources
      xj,yj     x,y locations of sources on 2D domain [-pi,pi]^2.
-     cj     size-nj complex FLT array of source strengths, 
+     cj     size-nj complex FLT array of source strengths,
             (ie, stored as 2*nj FLTs interleaving Re, Im).
      iflag  if >=0, uses + sign in exponential, otherwise - sign.
      eps    precision requested (>1e-16)
@@ -60,7 +60,7 @@ int finufft2d1(INT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,
   }
   cout << scientific << setprecision(15);  // for debug
 
-  if (opts.debug) printf("2d1: (ms,mt)=(%ld,%ld) (nf1,nf2)=(%ld,%ld) nj=%ld ...\n",(INT64)ms,(INT64)mt,nf1,nf2,(INT64)nj); 
+  if (opts.debug) printf("2d1: (ms,mt)=(%lld,%lld) (nf1,nf2)=(%lld,%lld) nj=%lld ...\n",(INT64)ms,(INT64)mt,nf1,nf2,(INT64)nj);
 
   // STEP 0: get Fourier coeffs of spread kernel in each dim:
   CNTime timer; timer.start();
@@ -113,8 +113,8 @@ int finufft2d2(INT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,FLT eps,
  /*  Type-2 2D complex nonuniform FFT.
 
      cj[j] =  SUM   fk[k1,k2] exp(+/-i (k1 xj[j] + k2 yj[j]))      for j = 0,...,nj-1
-             k1,k2 
-     where sum is over -ms/2 <= k1 <= (ms-1)/2, -mt/2 <= k2 <= (mt-1)/2, 
+             k1,k2
+     where sum is over -ms/2 <= k1 <= (ms-1)/2, -mt/2 <= k2 <= (mt-1)/2,
 
    Inputs:
      nj     number of sources (integer of type BIGINT; see utils.h)
@@ -153,7 +153,7 @@ int finufft2d2(INT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,FLT eps,
   }
   cout << scientific << setprecision(15);  // for debug
 
-  if (opts.debug) printf("2d2: (ms,mt)=(%ld,%ld) (nf1,nf2)=(%ld,%ld) nj=%ld ...\n",(INT64)ms,(INT64)mt,nf1,nf2,(INT64)nj); 
+  if (opts.debug) printf("2d2: (ms,mt)=(%lld,%lld) (nf1,nf2)=(%lld,%lld) nj=%lld ...\n",(INT64)ms,(INT64)mt,nf1,nf2,(INT64)nj);
 
   // STEP 0: get Fourier coeffs of spread kernel in each dim:
   CNTime timer; timer.start();
@@ -210,7 +210,7 @@ int finufft2d3(INT nj,FLT* xj,FLT* yj,CPX* cj,int iflag, FLT eps, INT nk, FLT* s
    Inputs:
      nj     number of sources (integer of type BIGINT; see utils.h)
      xj,yj  x,y location of sources in R^2.
-     cj     size-nj complex FLT array of source strengths, 
+     cj     size-nj complex FLT array of source strengths,
             (ie, stored as 2*nj FLTs interleaving Re, Im).
      nk     number of frequency target points
      s,t    (k_x,k_y) frequency locations of targets in R^2.
@@ -258,7 +258,7 @@ int finufft2d3(INT nj,FLT* xj,FLT* yj,CPX* cj,int iflag, FLT eps, INT nk, FLT* s
   // todo: if C1<X1/10 etc then set C1=0.0 and skip the slow-ish rephasing?
   set_nhg_type3(S1,X1,opts,spopts,&nf1,&h1,&gam1);          // applies twist i)
   set_nhg_type3(S2,X2,opts,spopts,&nf2,&h2,&gam2);
-  if (opts.debug) printf("2d3: X1=%.3g C1=%.3g S1=%.3g D1=%.3g gam1=%g nf1=%ld X2=%.3g C2=%.3g S2=%.3g D2=%.3g gam2=%g nf2=%ld nj=%ld nk=%ld...\n",X1,C1,S1,D1,gam1,nf1,X2,C2,S2,D2,gam2,nf2,(INT64)nj,(INT64)nk);
+  if (opts.debug) printf("2d3: X1=%.3g C1=%.3g S1=%.3g D1=%.3g gam1=%g nf1=%lld X2=%.3g C2=%.3g S2=%.3g D2=%.3g gam2=%g nf2=%lld nj=%lld nk=%lld...\n",X1,C1,S1,D1,gam1,nf1,X2,C2,S2,D2,gam2,nf2,(INT64)nj,(INT64)nk);
   if (nf1*nf2>MAX_NF) {
     fprintf(stderr,"nf1*nf2=%.3g exceeds MAX_NF of %.3g\n",(double)nf1*nf2,(double)MAX_NF);
     return ERR_MAXNALLOC;

--- a/src/finufft3d.cpp
+++ b/src/finufft3d.cpp
@@ -21,11 +21,11 @@ int finufft3d1(INT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,int iflag,
      The output array is in increasing k orderings. k1 is fastest, k2 middle,
      and k3 slowest, ie Fortran ordering. If iflag>0 the + sign is
      used, otherwise the - sign is used, in the exponential.
-                           
+
    Inputs:
      nj     number of sources (integer of type INT; see utils.h)
      xj,yj,zj   x,y,z locations of sources on 3D domain [-pi,pi]^3.
-     cj     size-nj complex FLT array of source strengths, 
+     cj     size-nj complex FLT array of source strengths,
             (ie, stored as 2*nj FLTs interleaving Re, Im).
      iflag  if >=0, uses + sign in exponential, otherwise - sign.
      eps    precision requested
@@ -63,7 +63,7 @@ int finufft3d1(INT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,int iflag,
   }
   cout << scientific << setprecision(15);  // for debug
 
-  if (opts.debug) printf("3d1: (ms,mt,mu)=(%ld,%ld,%ld) (nf1,nf2,nf3)=(%ld,%ld,%ld) nj=%ld ...\n",(INT64)ms,(INT64)mt,(INT64)mu,nf1,nf2,nf3,(INT64)nj); 
+  if (opts.debug) printf("3d1: (ms,mt,mu)=(%lld,%lld,%lld) (nf1,nf2,nf3)=(%lld,%lld,%lld) nj=%lld ...\n",(INT64)ms,(INT64)mt,(INT64)mu,nf1,nf2,nf3,(INT64)nj);
 
   // STEP 0: get DCT of half of spread kernel in each dim, since real symm:
   CNTime timer; timer.start();
@@ -92,7 +92,7 @@ int finufft3d1(INT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,int iflag,
   spopts.debug = opts.spread_debug;
   spopts.sort = opts.spread_sort;
   spopts.spread_direction = 1;
-  spopts.pirange = 1; FLT *dummy;
+  spopts.pirange = 1;
   int ier_spread = cnufftspread(nf1,nf2,nf3,(FLT*)fw,nj,xj,yj,zj,(FLT*)cj,spopts);
   if (opts.debug) printf("spread (ier=%d):\t\t %.3g s\n",ier_spread,timer.elapsedsec());
   if (ier_spread>0) exit(ier_spread);
@@ -122,7 +122,7 @@ int finufft3d2(INT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,
      cj[j] =    SUM   fk[k1,k2,k3] exp(+/-i (k1 xj[j] + k2 yj[j] + k3 zj[j]))
              k1,k2,k3
       for j = 0,...,nj-1
-     where sum is over -ms/2 <= k1 <= (ms-1)/2, -mt/2 <= k2 <= (mt-1)/2, 
+     where sum is over -ms/2 <= k1 <= (ms-1)/2, -mt/2 <= k2 <= (mt-1)/2,
                        -mu/2 <= k3 <= (mu-1)/2
 
    Inputs:
@@ -165,7 +165,7 @@ int finufft3d2(INT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,
   }
   cout << scientific << setprecision(15);  // for debug
 
-  if (opts.debug) printf("3d2: (ms,mt,mu)=(%ld,%ld,%ld) (nf1,nf2,nf3)=(%ld,%ld,%ld) nj=%ld ...\n",(INT64)ms,(INT64)mt,(INT64)mu,nf1,nf2,nf3,(INT64)nj);
+  if (opts.debug) printf("3d2: (ms,mt,mu)=(%lld,%lld,%lld) (nf1,nf2,nf3)=(%lld,%lld,%lld) nj=%lld ...\n",(INT64)ms,(INT64)mt,(INT64)mu,nf1,nf2,nf3,(INT64)nj);
 
   // STEP 0: get Fourier coeffs of spread kernel in each dim:
   CNTime timer; timer.start();
@@ -207,7 +207,7 @@ int finufft3d2(INT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,
   spopts.debug = opts.spread_debug;
   spopts.sort = opts.spread_sort;
   spopts.spread_direction = 2;
-  spopts.pirange = 1; FLT *dummy;
+  spopts.pirange = 1;
   int ier_spread = cnufftspread(nf1,nf2,nf3,(FLT*)fw,nj,xj,yj,zj,(FLT*)cj,spopts);
   if (opts.debug) printf("unspread (ier=%d):\t %.3g s\n",ier_spread,timer.elapsedsec());
   if (ier_spread>0) exit(ier_spread);
@@ -283,7 +283,7 @@ int finufft3d3(INT nj,FLT* xj,FLT* yj,FLT *zj, CPX* cj,
   set_nhg_type3(S2,X2,opts,spopts,&nf2,&h2,&gam2);
   set_nhg_type3(S3,X3,opts,spopts,&nf3,&h3,&gam3);
   if (opts.debug)
-    printf("3d3: X1=%.3g C1=%.3g S1=%.3g D1=%.3g gam1=%g nf1=%ld X2=%.3g C2=%.3g S2=%.3g D2=%.3g gam2=%g nf2=%ld X3=%.3g C3=%.3g S3=%.3g D3=%.3g gam3=%g nf3=%ld nj=%ld nk=%ld...\n",
+    printf("3d3: X1=%.3g C1=%.3g S1=%.3g D1=%.3g gam1=%g nf1=%lld X2=%.3g C2=%.3g S2=%.3g D2=%.3g gam2=%g nf2=%lld X3=%.3g C3=%.3g S3=%.3g D3=%.3g gam3=%g nf3=%lld nj=%lld nk=%lld...\n",
 	   X1,C1,S1,D1,gam1,nf1,X2,C2,S2,D2,gam2,nf2,X3,C3,S3,D3,gam3,nf3,(INT64)nj,(INT64)nk);
   if (nf1*nf2*nf3>MAX_NF) {
     fprintf(stderr,"nf1*nf2*nf3=%.3g exceeds MAX_NF of %.3g\n",(double)nf1*nf2*nf3,(double)MAX_NF);
@@ -307,14 +307,14 @@ int finufft3d3(INT nj,FLT* xj,FLT* yj,FLT *zj, CPX* cj,
   } else
     for (BIGINT j=0;j<nj;++j)
       cpj[j] = cj[j];                                    // just copy over
-  
+
   // Step 1: spread from irregular sources to regular grid as in type 1
   CPX* fw = (CPX*)malloc(sizeof(CPX)*nf1*nf2*nf3);
   timer.restart();
   spopts.debug = opts.spread_debug;
   spopts.sort = opts.spread_sort;
   spopts.spread_direction = 1;
-  spopts.pirange = 1; FLT *dummy;
+  spopts.pirange = 1;
   int ier_spread = cnufftspread(nf1,nf2,nf3,(FLT*)fw,nj,xpj,ypj,zpj,(FLT*)cpj,spopts);
   free(xpj); free(ypj); free(zpj); free(cpj);
   if (opts.debug) printf("spread (ier=%d):\t\t %.3g s\n",ier_spread,timer.elapsedsec());

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -105,7 +105,8 @@ using namespace std;
 
 void CNTime::start()
 {
-  gettimeofday(&initial, 0);
+  initial = clock();
+  //gettimeofday(&initial, 0);
 }
 
 int CNTime::restart()
@@ -118,15 +119,16 @@ int CNTime::restart()
 int CNTime::elapsed()
 //  returns answers as integer number of milliseconds
 {
-  struct timeval now;
-  gettimeofday(&now, 0);
-  int delta = 1000 * (now.tv_sec - (initial.tv_sec + 1));
-  delta += (now.tv_usec + (1000000 - initial.tv_usec)) / 1000;
-  return delta;
+  //struct timeval now;
+  //gettimeofday(&now, 0);
+  //int delta = 1000 * (now.tv_sec - (initial.tv_sec + 1));
+  //delta += (now.tv_usec + (1000000 - initial.tv_usec)) / 1000;
+  return int(elapsedsec() * 1000.0);
 }
 
 double CNTime::elapsedsec()
 //  returns answers as double in sec
 {
-  return (double)(this->elapsed()/1000.0);
+  return double(clock() - initial) / CLOCKS_PER_SEC;
+  //return (double)(this->elapsed()/1000.0);
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -106,7 +106,6 @@ using namespace std;
 void CNTime::start()
 {
   initial = clock();
-  //gettimeofday(&initial, 0);
 }
 
 int CNTime::restart()
@@ -119,10 +118,6 @@ int CNTime::restart()
 int CNTime::elapsed()
 //  returns answers as integer number of milliseconds
 {
-  //struct timeval now;
-  //gettimeofday(&now, 0);
-  //int delta = 1000 * (now.tv_sec - (initial.tv_sec + 1));
-  //delta += (now.tv_usec + (1000000 - initial.tv_usec)) / 1000;
   return int(elapsedsec() * 1000.0);
 }
 
@@ -130,5 +125,4 @@ double CNTime::elapsedsec()
 //  returns answers as double in sec
 {
   return double(clock() - initial) / CLOCKS_PER_SEC;
-  //return (double)(this->elapsed()/1000.0);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -48,7 +48,7 @@ typedef complex<double> dcomplex;  // slightly sneaky since duplicated by mwrap
   typedef double FLT;
   typedef complex<double> CPX;
   #define ima complex<double>{0.0,1.0}
-  #define FABS(x) fabsf(x)
+  #define FABS(x) std::abs(x)
   typedef fftw_complex FFTW_CPX;           // double-prec has fftw_*
   typedef fftw_plan FFTW_PLAN;
   #define FFTW_INIT fftw_init_threads

--- a/src/utils.h
+++ b/src/utils.h
@@ -109,7 +109,7 @@ INT64 next235even(INT64 n);
 
 
 // jfm timer stuff
-#include <sys/time.h>
+#include <time.h>
 class CNTime {
  public:
   void start();
@@ -117,7 +117,7 @@ class CNTime {
   int elapsed();
   double elapsedsec();
  private:
-  struct timeval initial;
+  clock_t initial;
 };
 
 


### PR DESCRIPTION
I started working on getting all this to build on Windows. I expect that this is something that you don't care about too much, but I've been trying to make my code as cross-platform as possible so I wanted to give it a shot! I'm not there yet, but I did switch out the timer code that you had for the C++ standard's `std::clock` instead of the deprecated `sys/time.h` code. This is probably a better interface either way.

I also cleared a few compiler warnings caused by ambiguous parens and formatting.

None of these changes should affect the output or compatibility (except to improve it!).