### PR TITLE
Revert "Modernizing timer code"

### DIFF
--- a/src/finufft1d.cpp
+++ b/src/finufft1d.cpp
@@ -12,7 +12,7 @@ int finufft1d1(INT nj,FLT* xj,CPX* cj,int iflag,FLT eps,INT ms,
 
               nj-1
      fk(k1) = SUM cj[j] exp(+/-i k1 xj(j))  for -ms/2 <= k1 <= (ms-1)/2
-              j=0
+              j=0                            
    Inputs:
      nj     number of sources (type INT; see utils.h)
      xj     location of sources on interval [-pi,pi].
@@ -54,7 +54,7 @@ int finufft1d1(INT nj,FLT* xj,CPX* cj,int iflag,FLT eps,INT ms,
   }
   cout << scientific << setprecision(15);  // for debug
 
-  if (opts.debug) printf("1d1: ms=%lld nf1=%lld nj=%lld ...\n",(INT64)ms,nf1,(INT64)nj);
+  if (opts.debug) printf("1d1: ms=%ld nf1=%ld nj=%ld ...\n",(INT64)ms,nf1,(INT64)nj);
 
   CNTime timer; timer.start();
   int nth = MY_OMP_GET_MAX_THREADS();
@@ -108,7 +108,7 @@ int finufft1d2(INT nj,FLT* xj,CPX* cj,int iflag,FLT eps,INT ms,
  /*  Type-2 1D complex nonuniform FFT.
 
      cj[j] = SUM   fk[k1] exp(+/-i k1 xj[j])      for j = 0,...,nj-1
-             k1
+             k1 
      where sum is over -ms/2 <= k1 <= (ms-1)/2.
 
    Inputs:
@@ -150,7 +150,7 @@ int finufft1d2(INT nj,FLT* xj,CPX* cj,int iflag,FLT eps,INT ms,
   }
   cout << scientific << setprecision(15);  // for debug
 
-  if (opts.debug) printf("1d2: ms=%lld nf1=%lld nj=%lld ...\n",(INT64)ms,nf1,(INT64)nj);
+  if (opts.debug) printf("1d2: ms=%ld nf1=%ld nj=%ld ...\n",(INT64)ms,nf1,(INT64)nj); 
 
   // STEP 0: get FT of real symmetric spreading kernel
   CNTime timer; timer.start();
@@ -236,7 +236,7 @@ int finufft1d3(INT nj,FLT* xj,CPX* cj,int iflag, FLT eps, INT nk, FLT* s, CPX* f
 
    No references to FFTW are needed here. CPX arithmetic is used,
    thus compile with -Ofast in GNU.
-   Barnett 2/7/17-6/9/17.
+   Barnett 2/7/17-6/9/17. 
  */
 {
   spread_opts spopts;
@@ -251,7 +251,7 @@ int finufft1d3(INT nj,FLT* xj,CPX* cj,int iflag, FLT eps, INT nk, FLT* s, CPX* f
   arraywidcen((BIGINT)nj,xj,&X1,&C1);  // get half-width, center, containing {x_j}
   arraywidcen((BIGINT)nk,s,&S1,&D1);   // get half-width, center, containing {s_k}
   set_nhg_type3(S1,X1,opts,spopts,&nf1,&h1,&gam1);          // applies twist i)
-  if (opts.debug) printf("1d3: X1=%.3g C1=%.3g S1=%.3g D1=%.3g gam1=%g nf1=%lld nj=%lld nk=%lld...\n",X1,C1,S1,D1,gam1,nf1,(INT64)nj,(INT64)nk);
+  if (opts.debug) printf("1d3: X1=%.3g C1=%.3g S1=%.3g D1=%.3g gam1=%g nf1=%ld nj=%ld nk=%ld...\n",X1,C1,S1,D1,gam1,nf1,(INT64)nj,(INT64)nk);
   if (nf1>MAX_NF) {
     fprintf(stderr,"nf1=%.3g exceeds MAX_NF of %.3g\n",(double)nf1,(double)MAX_NF);
     return ERR_MAXNALLOC;
@@ -269,7 +269,7 @@ int finufft1d3(INT nj,FLT* xj,CPX* cj,int iflag, FLT eps, INT nk, FLT* s, CPX* f
   } else
     for (BIGINT j=0;j<nj;++j)
       cpj[j] = cj[j];                                    // just copy over
-
+  
   // Step 1: spread from irregular sources to regular grid as in type 1
   CPX* fw = (CPX*)malloc(sizeof(CPX)*nf1);
   timer.restart();

--- a/src/finufft2d.cpp
+++ b/src/finufft2d.cpp
@@ -13,17 +13,17 @@ int finufft2d1(INT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,
                   nj-1
      f[k1,k2] =   SUM  c[j] exp(+-i (k1 x[j] + k2 y[j]))
                   j=0
-
+ 
      for -ms/2 <= k1 <= (ms-1)/2,  -mt/2 <= k2 <= (mt-1)/2.
 
      The output array is in increasing k1 ordering (fast), then increasing
      k2 ordering (slow). If iflag>0 the + sign is
      used, otherwise the - sign is used, in the exponential.
-
+                           
    Inputs:
      nj     number of sources
      xj,yj     x,y locations of sources on 2D domain [-pi,pi]^2.
-     cj     size-nj complex FLT array of source strengths,
+     cj     size-nj complex FLT array of source strengths, 
             (ie, stored as 2*nj FLTs interleaving Re, Im).
      iflag  if >=0, uses + sign in exponential, otherwise - sign.
      eps    precision requested (>1e-16)
@@ -60,7 +60,7 @@ int finufft2d1(INT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,
   }
   cout << scientific << setprecision(15);  // for debug
 
-  if (opts.debug) printf("2d1: (ms,mt)=(%lld,%lld) (nf1,nf2)=(%lld,%lld) nj=%lld ...\n",(INT64)ms,(INT64)mt,nf1,nf2,(INT64)nj);
+  if (opts.debug) printf("2d1: (ms,mt)=(%ld,%ld) (nf1,nf2)=(%ld,%ld) nj=%ld ...\n",(INT64)ms,(INT64)mt,nf1,nf2,(INT64)nj); 
 
   // STEP 0: get Fourier coeffs of spread kernel in each dim:
   CNTime timer; timer.start();
@@ -113,8 +113,8 @@ int finufft2d2(INT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,FLT eps,
  /*  Type-2 2D complex nonuniform FFT.
 
      cj[j] =  SUM   fk[k1,k2] exp(+/-i (k1 xj[j] + k2 yj[j]))      for j = 0,...,nj-1
-             k1,k2
-     where sum is over -ms/2 <= k1 <= (ms-1)/2, -mt/2 <= k2 <= (mt-1)/2,
+             k1,k2 
+     where sum is over -ms/2 <= k1 <= (ms-1)/2, -mt/2 <= k2 <= (mt-1)/2, 
 
    Inputs:
      nj     number of sources (integer of type BIGINT; see utils.h)
@@ -153,7 +153,7 @@ int finufft2d2(INT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,FLT eps,
   }
   cout << scientific << setprecision(15);  // for debug
 
-  if (opts.debug) printf("2d2: (ms,mt)=(%lld,%lld) (nf1,nf2)=(%lld,%lld) nj=%lld ...\n",(INT64)ms,(INT64)mt,nf1,nf2,(INT64)nj);
+  if (opts.debug) printf("2d2: (ms,mt)=(%ld,%ld) (nf1,nf2)=(%ld,%ld) nj=%ld ...\n",(INT64)ms,(INT64)mt,nf1,nf2,(INT64)nj); 
 
   // STEP 0: get Fourier coeffs of spread kernel in each dim:
   CNTime timer; timer.start();
@@ -210,7 +210,7 @@ int finufft2d3(INT nj,FLT* xj,FLT* yj,CPX* cj,int iflag, FLT eps, INT nk, FLT* s
    Inputs:
      nj     number of sources (integer of type BIGINT; see utils.h)
      xj,yj  x,y location of sources in R^2.
-     cj     size-nj complex FLT array of source strengths,
+     cj     size-nj complex FLT array of source strengths, 
             (ie, stored as 2*nj FLTs interleaving Re, Im).
      nk     number of frequency target points
      s,t    (k_x,k_y) frequency locations of targets in R^2.
@@ -258,7 +258,7 @@ int finufft2d3(INT nj,FLT* xj,FLT* yj,CPX* cj,int iflag, FLT eps, INT nk, FLT* s
   // todo: if C1<X1/10 etc then set C1=0.0 and skip the slow-ish rephasing?
   set_nhg_type3(S1,X1,opts,spopts,&nf1,&h1,&gam1);          // applies twist i)
   set_nhg_type3(S2,X2,opts,spopts,&nf2,&h2,&gam2);
-  if (opts.debug) printf("2d3: X1=%.3g C1=%.3g S1=%.3g D1=%.3g gam1=%g nf1=%lld X2=%.3g C2=%.3g S2=%.3g D2=%.3g gam2=%g nf2=%lld nj=%lld nk=%lld...\n",X1,C1,S1,D1,gam1,nf1,X2,C2,S2,D2,gam2,nf2,(INT64)nj,(INT64)nk);
+  if (opts.debug) printf("2d3: X1=%.3g C1=%.3g S1=%.3g D1=%.3g gam1=%g nf1=%ld X2=%.3g C2=%.3g S2=%.3g D2=%.3g gam2=%g nf2=%ld nj=%ld nk=%ld...\n",X1,C1,S1,D1,gam1,nf1,X2,C2,S2,D2,gam2,nf2,(INT64)nj,(INT64)nk);
   if (nf1*nf2>MAX_NF) {
     fprintf(stderr,"nf1*nf2=%.3g exceeds MAX_NF of %.3g\n",(double)nf1*nf2,(double)MAX_NF);
     return ERR_MAXNALLOC;

--- a/src/finufft3d.cpp
+++ b/src/finufft3d.cpp
@@ -21,11 +21,11 @@ int finufft3d1(INT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,int iflag,
      The output array is in increasing k orderings. k1 is fastest, k2 middle,
      and k3 slowest, ie Fortran ordering. If iflag>0 the + sign is
      used, otherwise the - sign is used, in the exponential.
-
+                           
    Inputs:
      nj     number of sources (integer of type INT; see utils.h)
      xj,yj,zj   x,y,z locations of sources on 3D domain [-pi,pi]^3.
-     cj     size-nj complex FLT array of source strengths,
+     cj     size-nj complex FLT array of source strengths, 
             (ie, stored as 2*nj FLTs interleaving Re, Im).
      iflag  if >=0, uses + sign in exponential, otherwise - sign.
      eps    precision requested
@@ -63,7 +63,7 @@ int finufft3d1(INT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,int iflag,
   }
   cout << scientific << setprecision(15);  // for debug
 
-  if (opts.debug) printf("3d1: (ms,mt,mu)=(%lld,%lld,%lld) (nf1,nf2,nf3)=(%lld,%lld,%lld) nj=%lld ...\n",(INT64)ms,(INT64)mt,(INT64)mu,nf1,nf2,nf3,(INT64)nj);
+  if (opts.debug) printf("3d1: (ms,mt,mu)=(%ld,%ld,%ld) (nf1,nf2,nf3)=(%ld,%ld,%ld) nj=%ld ...\n",(INT64)ms,(INT64)mt,(INT64)mu,nf1,nf2,nf3,(INT64)nj); 
 
   // STEP 0: get DCT of half of spread kernel in each dim, since real symm:
   CNTime timer; timer.start();
@@ -92,7 +92,7 @@ int finufft3d1(INT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,int iflag,
   spopts.debug = opts.spread_debug;
   spopts.sort = opts.spread_sort;
   spopts.spread_direction = 1;
-  spopts.pirange = 1;
+  spopts.pirange = 1; FLT *dummy;
   int ier_spread = cnufftspread(nf1,nf2,nf3,(FLT*)fw,nj,xj,yj,zj,(FLT*)cj,spopts);
   if (opts.debug) printf("spread (ier=%d):\t\t %.3g s\n",ier_spread,timer.elapsedsec());
   if (ier_spread>0) exit(ier_spread);
@@ -122,7 +122,7 @@ int finufft3d2(INT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,
      cj[j] =    SUM   fk[k1,k2,k3] exp(+/-i (k1 xj[j] + k2 yj[j] + k3 zj[j]))
              k1,k2,k3
       for j = 0,...,nj-1
-     where sum is over -ms/2 <= k1 <= (ms-1)/2, -mt/2 <= k2 <= (mt-1)/2,
+     where sum is over -ms/2 <= k1 <= (ms-1)/2, -mt/2 <= k2 <= (mt-1)/2, 
                        -mu/2 <= k3 <= (mu-1)/2
 
    Inputs:
@@ -165,7 +165,7 @@ int finufft3d2(INT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,
   }
   cout << scientific << setprecision(15);  // for debug
 
-  if (opts.debug) printf("3d2: (ms,mt,mu)=(%lld,%lld,%lld) (nf1,nf2,nf3)=(%lld,%lld,%lld) nj=%lld ...\n",(INT64)ms,(INT64)mt,(INT64)mu,nf1,nf2,nf3,(INT64)nj);
+  if (opts.debug) printf("3d2: (ms,mt,mu)=(%ld,%ld,%ld) (nf1,nf2,nf3)=(%ld,%ld,%ld) nj=%ld ...\n",(INT64)ms,(INT64)mt,(INT64)mu,nf1,nf2,nf3,(INT64)nj);
 
   // STEP 0: get Fourier coeffs of spread kernel in each dim:
   CNTime timer; timer.start();
@@ -207,7 +207,7 @@ int finufft3d2(INT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,
   spopts.debug = opts.spread_debug;
   spopts.sort = opts.spread_sort;
   spopts.spread_direction = 2;
-  spopts.pirange = 1;
+  spopts.pirange = 1; FLT *dummy;
   int ier_spread = cnufftspread(nf1,nf2,nf3,(FLT*)fw,nj,xj,yj,zj,(FLT*)cj,spopts);
   if (opts.debug) printf("unspread (ier=%d):\t %.3g s\n",ier_spread,timer.elapsedsec());
   if (ier_spread>0) exit(ier_spread);
@@ -283,7 +283,7 @@ int finufft3d3(INT nj,FLT* xj,FLT* yj,FLT *zj, CPX* cj,
   set_nhg_type3(S2,X2,opts,spopts,&nf2,&h2,&gam2);
   set_nhg_type3(S3,X3,opts,spopts,&nf3,&h3,&gam3);
   if (opts.debug)
-    printf("3d3: X1=%.3g C1=%.3g S1=%.3g D1=%.3g gam1=%g nf1=%lld X2=%.3g C2=%.3g S2=%.3g D2=%.3g gam2=%g nf2=%lld X3=%.3g C3=%.3g S3=%.3g D3=%.3g gam3=%g nf3=%lld nj=%lld nk=%lld...\n",
+    printf("3d3: X1=%.3g C1=%.3g S1=%.3g D1=%.3g gam1=%g nf1=%ld X2=%.3g C2=%.3g S2=%.3g D2=%.3g gam2=%g nf2=%ld X3=%.3g C3=%.3g S3=%.3g D3=%.3g gam3=%g nf3=%ld nj=%ld nk=%ld...\n",
 	   X1,C1,S1,D1,gam1,nf1,X2,C2,S2,D2,gam2,nf2,X3,C3,S3,D3,gam3,nf3,(INT64)nj,(INT64)nk);
   if (nf1*nf2*nf3>MAX_NF) {
     fprintf(stderr,"nf1*nf2*nf3=%.3g exceeds MAX_NF of %.3g\n",(double)nf1*nf2*nf3,(double)MAX_NF);
@@ -307,14 +307,14 @@ int finufft3d3(INT nj,FLT* xj,FLT* yj,FLT *zj, CPX* cj,
   } else
     for (BIGINT j=0;j<nj;++j)
       cpj[j] = cj[j];                                    // just copy over
-
+  
   // Step 1: spread from irregular sources to regular grid as in type 1
   CPX* fw = (CPX*)malloc(sizeof(CPX)*nf1*nf2*nf3);
   timer.restart();
   spopts.debug = opts.spread_debug;
   spopts.sort = opts.spread_sort;
   spopts.spread_direction = 1;
-  spopts.pirange = 1;
+  spopts.pirange = 1; FLT *dummy;
   int ier_spread = cnufftspread(nf1,nf2,nf3,(FLT*)fw,nj,xpj,ypj,zpj,(FLT*)cpj,spopts);
   free(xpj); free(ypj); free(zpj); free(cpj);
   if (opts.debug) printf("spread (ier=%d):\t\t %.3g s\n",ier_spread,timer.elapsedsec());

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -105,7 +105,7 @@ using namespace std;
 
 void CNTime::start()
 {
-  initial = clock();
+  gettimeofday(&initial, 0);
 }
 
 int CNTime::restart()
@@ -118,11 +118,15 @@ int CNTime::restart()
 int CNTime::elapsed()
 //  returns answers as integer number of milliseconds
 {
-  return int(elapsedsec() * 1000.0);
+  struct timeval now;
+  gettimeofday(&now, 0);
+  int delta = 1000 * (now.tv_sec - (initial.tv_sec + 1));
+  delta += (now.tv_usec + (1000000 - initial.tv_usec)) / 1000;
+  return delta;
 }
 
 double CNTime::elapsedsec()
 //  returns answers as double in sec
 {
-  return double(clock() - initial) / CLOCKS_PER_SEC;
+  return (double)(this->elapsed()/1000.0);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -48,7 +48,7 @@ typedef complex<double> dcomplex;  // slightly sneaky since duplicated by mwrap
   typedef double FLT;
   typedef complex<double> CPX;
   #define ima complex<double>{0.0,1.0}
-  #define FABS(x) std::abs(x)
+  #define FABS(x) fabsf(x)
   typedef fftw_complex FFTW_CPX;           // double-prec has fftw_*
   typedef fftw_plan FFTW_PLAN;
   #define FFTW_INIT fftw_init_threads
@@ -109,7 +109,7 @@ INT64 next235even(INT64 n);
 
 
 // jfm timer stuff
-#include <time.h>
+#include <sys/time.h>
 class CNTime {
  public:
   void start();
@@ -117,7 +117,7 @@ class CNTime {
   int elapsed();
   double elapsedsec();
  private:
-  clock_t initial;
+  struct timeval initial;
 };
 
 


### PR DESCRIPTION
Reverts ahbarnett/finufft#9    since dfm's new std::clock seems not to give wall time, but sum of threads time.