### PR TITLE
Fix #17

### DIFF
--- a/makefile
+++ b/makefile
@@ -183,8 +183,8 @@ matlab: lib-static/libfinufft.a $(HEADERS)
 	$(MEX) matlab/finufft.cpp lib-static/libfinufft.a matlab/finufft_m.cpp $(MFLAGS) $(LIBSFFT) -output matlab/finufft
 
 # octave .mex executable... (notice also creates matlab/finufft.o, but why?)
-octave: lib-static/libfinufft.a $(HEADERS) matlab/finufft_m.o
-	(cd matlab; mkoctfile --mex finufft.cpp ../lib-static/libfinufft.a finufft_m.o $(OFLAGS) $(LIBSFFT) -output finufft)
+octave: lib-static/libfinufft.a $(HEADERS)
+	(cd matlab; mkoctfile --mex finufft.cpp ../lib-static/libfinufft.a finufft_m.cpp $(OFLAGS) $(LIBSFFT) -output finufft)
 	@echo "Running octave interface test; please wait a few seconds..."
 	(cd matlab; octave check_finufft.m)
 

--- a/makefile
+++ b/makefile
@@ -179,8 +179,8 @@ fortran: $(FOBJS) $(OBJS) $(HEADERS)
 	time -p $(F3)
 
 # matlab .mex* executable...
-matlab: lib-static/libfinufft.a $(HEADERS) matlab/finufft_m.o
-	$(MEX) matlab/finufft.cpp lib-static/libfinufft.a matlab/finufft_m.o $(MFLAGS) $(LIBSFFT) -output matlab/finufft
+matlab: lib-static/libfinufft.a $(HEADERS)
+	$(MEX) matlab/finufft.cpp lib-static/libfinufft.a matlab/finufft_m.cpp $(MFLAGS) $(LIBSFFT) -output matlab/finufft
 
 # octave .mex executable... (notice also creates matlab/finufft.o, but why?)
 octave: lib-static/libfinufft.a $(HEADERS) matlab/finufft_m.o

--- a/matlab/finufft_m.cpp
+++ b/matlab/finufft_m.cpp
@@ -10,8 +10,15 @@
 #include "../src/finufft.h"
 #include <stdio.h>
 #include <math.h>
+#include <mex.h>
 
 #define IROUND(x) (int)round(x)
+
+void finufft_mex_setup()
+{
+  /* Forces MATLAB to properly initialize their FFTW library. */
+  mexEvalString("fft(1:8);");
+}
 
 void finufft_mex_opts(nufft_opts &opts, double *mexo)
 // global setup of finufft opts given MEX interface opts 6-long double array.
@@ -35,6 +42,7 @@ void finufft_mex_opts(nufft_opts &opts, double *mexo)
 int finufft1d1m(double nj,double* xj,dcomplex* cj,int iflag,double eps,double ms, dcomplex* fk, double* mexo)
 {
   nufft_opts opts;
+  finufft_mex_setup();
   finufft_mex_opts(opts, mexo);
   return finufft1d1((BIGINT)(nj+0.5),xj,cj,iflag,eps,(BIGINT)(ms+0.5),fk,opts);
 }
@@ -42,6 +50,7 @@ int finufft1d1m(double nj,double* xj,dcomplex* cj,int iflag,double eps,double ms
 int finufft1d2m(double nj,double* xj,dcomplex* cj,int iflag,double eps,double ms, dcomplex* fk, double* mexo)
 {
   nufft_opts opts;
+  finufft_mex_setup();
   finufft_mex_opts(opts, mexo);
   return finufft1d2((BIGINT)(nj+0.5),xj,cj,iflag,eps,(BIGINT)(ms+0.5),fk,opts);
 }
@@ -49,6 +58,7 @@ int finufft1d2m(double nj,double* xj,dcomplex* cj,int iflag,double eps,double ms
 int finufft1d3m(double nj,double* xj,dcomplex* cj,int iflag,double eps,double nk, double* s, dcomplex* fk, double* mexo)
 {
   nufft_opts opts;
+  finufft_mex_setup();
   finufft_mex_opts(opts, mexo);
   return finufft1d3((BIGINT)(nj+0.5),xj,cj,iflag,eps,(BIGINT)(nk+0.5),s,fk,opts);
 }
@@ -56,6 +66,7 @@ int finufft1d3m(double nj,double* xj,dcomplex* cj,int iflag,double eps,double nk
 int finufft2d1m(double nj,double* xj,double* yj, dcomplex* cj,int iflag,double eps,double ms, double mt, dcomplex* fk, double *mexo)
 {
   nufft_opts opts;
+  finufft_mex_setup();
   finufft_mex_opts(opts, mexo);
   return finufft2d1((BIGINT)(nj+0.5),xj,yj,cj,iflag,eps,(BIGINT)(ms+0.5),(BIGINT)(mt+0.5),fk,opts);
 }
@@ -63,6 +74,7 @@ int finufft2d1m(double nj,double* xj,double* yj, dcomplex* cj,int iflag,double e
 int finufft2d2m(double nj,double* xj,double* yj,dcomplex* cj,int iflag,double eps,double ms, double mt, dcomplex* fk, double* mexo)
 {
   nufft_opts opts;
+  finufft_mex_setup();
   finufft_mex_opts(opts, mexo);
   return finufft2d2((BIGINT)(nj+0.5),xj,yj,cj,iflag,eps,(BIGINT)(ms+0.5),(BIGINT)(mt+0.5),fk,opts);
 }
@@ -70,6 +82,7 @@ int finufft2d2m(double nj,double* xj,double* yj,dcomplex* cj,int iflag,double ep
 int finufft2d3m(double nj,double* xj,double *yj,dcomplex* cj,int iflag,double eps,double nk, double* s, double* t, dcomplex* fk, double* mexo)
 {
   nufft_opts opts;
+  finufft_mex_setup();
   finufft_mex_opts(opts, mexo);
   return finufft2d3((BIGINT)(nj+0.5),xj,yj,cj,iflag,eps,(BIGINT)(nk+0.5),s,t,fk,opts);
 }
@@ -77,6 +90,7 @@ int finufft2d3m(double nj,double* xj,double *yj,dcomplex* cj,int iflag,double ep
 int finufft3d1m(double nj,double* xj,double* yj, double* zj, dcomplex* cj,int iflag,double eps,double ms, double mt, double mu, dcomplex* fk, double* mexo)
 {
   nufft_opts opts;
+  finufft_mex_setup();
   finufft_mex_opts(opts, mexo);
   return finufft3d1((BIGINT)(nj+0.5),xj,yj,zj,cj,iflag,eps,(BIGINT)(ms+0.5),(BIGINT)(mt+0.5),(BIGINT)(mu+0.5),fk,opts);
 }
@@ -84,6 +98,7 @@ int finufft3d1m(double nj,double* xj,double* yj, double* zj, dcomplex* cj,int if
 int finufft3d2m(double nj,double* xj,double* yj,double *zj,dcomplex* cj,int iflag,double eps,double ms, double mt, double mu, dcomplex* fk, double* mexo)
 {
   nufft_opts opts;
+  finufft_mex_setup();
   finufft_mex_opts(opts, mexo);
   return finufft3d2((BIGINT)(nj+0.5),xj,yj,zj,cj,iflag,eps,(BIGINT)(ms+0.5),(BIGINT)(mt+0.5),(BIGINT)(mu+0.5),fk,opts);
 }
@@ -91,6 +106,7 @@ int finufft3d2m(double nj,double* xj,double* yj,double *zj,dcomplex* cj,int ifla
 int finufft3d3m(double nj,double* xj,double *yj,double *zj,dcomplex* cj,int iflag,double eps,double nk, double* s, double* t, double *u, dcomplex* fk, double* mexo)
   {
   nufft_opts opts;
+  finufft_mex_setup();
   finufft_mex_opts(opts, mexo);
   return finufft3d3((BIGINT)(nj+0.5),xj,yj,zj,cj,iflag,eps,(BIGINT)(nk+0.5),s,t,u,fk,opts);
 }


### PR DESCRIPTION
By calling a small FFT in each MEX call, we can prevent MATLAB from crashing when calling FFTW within FINUFFT.